### PR TITLE
Upgrade core version to use MongoDB client with timeout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <description>NFRR Audit Collector</description>
     <packaging>jar</packaging>
     <url>https://github.com/Hygieia/${repository.name}</url>
-    <version>3.1.3-SNAPSHOT</version>
+    <version>3.1.4-SNAPSHOT</version>
     <artifactId>nfrr-audit-collector</artifactId>
 
     <parent>
@@ -51,7 +51,7 @@
         <repository.name>hygieia-audit-nfrr-collector</repository.name>
         <apache.rat.plugin.version>0.13</apache.rat.plugin.version>
         <bc.version>3.0.1</bc.version>
-        <com.capitalone.dashboard.core.version>3.1.12</com.capitalone.dashboard.core.version>
+        <com.capitalone.dashboard.core.version>3.7.2</com.capitalone.dashboard.core.version>
         <commons.io.version>2.4</commons.io.version>
         <commons.lang.version>3.8.1</commons.lang.version>
         <coveralls.maven.plugin.version>4.3.0</coveralls.maven.plugin.version>


### PR DESCRIPTION
This is to prevent the collector stuck at waiting for MongoDB responses.